### PR TITLE
fix: update  sorting by delegator by tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 main
 
 dist/
+.idea

--- a/validators.go
+++ b/validators.go
@@ -151,9 +151,9 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			Msg("Finished querying validators")
 		validators = validatorsResponse.Validators
 
-		// sorting by delegator shares to display rankings
+		// sorting by delegator tokens to display rankings
 		sort.Slice(validators, func(i, j int) bool {
-			return validators[i].DelegatorShares.RoundInt64() > validators[j].DelegatorShares.RoundInt64()
+			return validators[i].Tokens.GT(validators[j].Tokens)
 		})
 	}()
 


### PR DESCRIPTION
When I tried to run cosmos-exporter  with sifchain I met this problem:
![Screenshot 2022-11-28 at 11 10 40](https://user-images.githubusercontent.com/32406476/204192702-38c478f6-f698-4fec-96ef-674d1392e985.png)

I found we can fix this issue by comparing big number value in Tokens field of Validator info

I hope you can merge PR to resolve this problem