### PR TITLE
fix: panic: Int64() out of bound on DelegatorShares comparison

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -153,7 +153,7 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 
 		// sorting by delegator shares to display rankings
 		sort.Slice(validators, func(i, j int) bool {
-			return validators[i].DelegatorShares.RoundInt64() > validators[j].DelegatorShares.RoundInt64()
+			return validators[i].DelegatorShares.GT(validators[j].DelegatorShares)
 		})
 	}()
 


### PR DESCRIPTION
The `/metrics/validators` was crashing with:
```
panic: Int64() out of bound
goroutine 216 [running]:
github.com/cosmos/cosmos-sdk/types.Dec.RoundInt64({0xc000d9fe78?})
        /go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.42.4/types/decimal.go:554 +0x8b
main.ValidatorsHandler.func1.1(0x0?, 0x0)
        /app/cosmos-exporter-5f4936f0e725eff970995a34e67b85c7a1c65bda/validators.go:156 +0x45
sort.insertionSort_func({0xc000d9ffb8?, 0xc001109b90?}, 0x0, 0x3)
        /usr/local/go/src/sort/zsortfunc.go:12 +0xb1
sort.pdqsort_func({0xc000d9ffb8?, 0xc001109b90?}, 0x3e938d0765b8?, 0x18?, 0xc000066800?)
        /usr/local/go/src/sort/zsortfunc.go:73 +0x2dd
sort.Slice({0x10e6620?, 0xc001063098?}, 0x4?)
        /usr/local/go/src/sort/slice.go:26 +0xfa
main.ValidatorsHandler.func1()
        /app/cosmos-exporter-5f4936f0e725eff970995a34e67b85c7a1c65bda/validators.go:155 +0x31c
created by main.ValidatorsHandler
        /app/cosmos-exporter-5f4936f0e725eff970995a34e67b85c7a1c65bda/validators.go:130 +0x16b3
```
Closes #20