### PR TITLE
fix: Set validator delegations limit

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -263,7 +263,12 @@ func ValidatorHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cli
 		stakingClient := stakingtypes.NewQueryClient(grpcConn)
 		stakingRes, err := stakingClient.ValidatorDelegations(
 			context.Background(),
-			&stakingtypes.QueryValidatorDelegationsRequest{ValidatorAddr: myAddress.String()},
+			&stakingtypes.QueryValidatorDelegationsRequest{
+				ValidatorAddr: myAddress.String(),
+				Pagination: &querytypes.PageRequest{
+					Limit: Limit,
+				},
+			},
 		)
 		if err != nil {
 			sublogger.Error().


### PR DESCRIPTION
Use the global config limit (defaults to 1000)

Before the fix:
![image](https://user-images.githubusercontent.com/24973/219474632-51888457-f5fc-4a8c-a6fb-dfa85042dd09.png)
After the fix:
![image](https://user-images.githubusercontent.com/24973/219474822-d5704dde-3754-4b5a-b146-5ac978c0b0e9.png)
